### PR TITLE
text: Indicate battery is charging

### DIFF
--- a/src/drawicon.js
+++ b/src/drawicon.js
@@ -79,10 +79,10 @@ var BatteryDrawIcon = GObject.registerClass(
       this.queue_repaint();
     }
 
-    vfunc_repaint() {
+    get iconColors() {
       const themeNode = this.get_theme_node();
       // Get colors from idol icon (StIcon)
-      const iconColors = this.idolWidget
+      return this.idolWidget
         ? St.ThemeNode.new(
             St.ThemeContext.get_for_stage(global.stage) /* context */,
             themeNode.get_parent() /* parent_node */,
@@ -94,12 +94,23 @@ var BatteryDrawIcon = GObject.registerClass(
             this.idolWidget.style ?? '' /* inline_style */
           ).get_icon_colors()
         : themeNode.get_icon_colors();
+    }
+
+    vfunc_repaint() {
+      const themeNode = this.get_theme_node();
+      const iconColors = this.iconColors;
       const slim = this.statusStyle === BStatusStyle.SLIM;
       const fColor = iconColors.foreground;
       const bColor = fColor.copy();
       bColor.alpha *= 0.5;
       const fillColor =
-        this.percentage > 15 ? (slim ? bColor : fColor) : iconColors.warning;
+        this.percentage > 15
+          ? slim
+            ? bColor
+            : fColor
+          : this.percentage > 5
+          ? iconColors.warning
+          : iconColors.error;
 
       // Draw battery icon
       const p = this.percentage / 100;

--- a/src/extension.js
+++ b/src/extension.js
@@ -149,10 +149,10 @@ class Extension {
 
     // Disconnect proxy
     this._proxy.disconnect(this._proxyId);
-    if ('_proxy_real' in sysIndicator) {
-      sysIndicator._proxy.destroy();
-      sysIndicator._proxy = sysIndicator._proxy_real;
-      delete sysIndicator._proxy_real;
+    if ('_proxy_real' in powerToggle) {
+      powerToggle._proxy.destroy();
+      powerToggle._proxy = powerToggle._proxy_real;
+      delete powerToggle._proxy_real;
     }
     this._proxy = null;
     this._proxyId = null;

--- a/src/mock.js
+++ b/src/mock.js
@@ -36,7 +36,6 @@ var PowerManagerProxyMock = GObject.registerClass(
         clearInterval(this._debugIntervalId);
         this._debugIntervalId = null;
       }
-      super.destroy();
     }
   }
 );


### PR DESCRIPTION
LineageOS does not indicate charging in `Text` mode, however, (I also think #11) it makes sense to indicate it somehow.

The simplest approach is simply using the (green) icon `success` color to indicate charging:
![battery-charging-green](https://github.com/Deminder/battery-indicator-icon/assets/18591813/96e1e3c5-799a-4c13-b9c7-121da5b8a65d)

However, the green color could be distracting or hard to see. So, it might look better with a line over the text:
![text-only_border-top](https://github.com/Deminder/battery-indicator-icon/assets/18591813/a4bee5e8-7fa0-423e-a9d9-9405358fa233)
```css
.battery-charging.text-only StLabel {
  border-top: solid 3px rgba(255, 255, 255, 0.75);
  padding-bottom: 3px;
  border-radius: 3px;
}
```

I also considered this:
![text-only_lime-shadow](https://github.com/Deminder/battery-indicator-icon/assets/18591813/ff6bdf01-ca70-4436-bc62-611085685bbb)
```css
.battery-charging.text-only StLabel {
  text-shadow: lime 0 0 7.5px;
  color: white;
}
```
but this does not feel appropriate.

@cbcb00 Let me know if you have any ideas to improve this.

