### PR TITLE
Fix extension enable setup triggered too early

### DIFF
--- a/po/main.pot
+++ b/po/main.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Battery Indicator Icon 15\n"
+"Project-Id-Version: Battery Indicator Icon 18\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-30 13:32+0200\n"
+"POT-Creation-Date: 2025-03-30 13:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/src/extension.js
+++ b/src/extension.js
@@ -42,8 +42,10 @@ export default class BatteryIndicatorIcon extends Extension {
         qs,
         '_addItems' in qs ? '_addItems' : '_addItemsBefore',
         (...args) => {
-          this._setup(qs);
-          injection.clear();
+          if ('_system' in qs) {
+            this._setup(qs);
+            injection.clear();
+          }
           injection.previous.call(qs, ...args);
         }
       );


### PR DESCRIPTION
The setup of this extension was triggered earlier than expected when another extension calls `quicksettings.addExternalIndicator`.

Fix bad extension setup by wating for setup of `quicksettings._system`.

Fixes: https://github.com/Deminder/battery-indicator-icon/issues/25